### PR TITLE
AGS-9: fix jagentic-core compile error that broke the whole JVM build

### DIFF
--- a/ports/jagentic-core/src/main/java/org/jagentic/core/Retrieval.java
+++ b/ports/jagentic-core/src/main/java/org/jagentic/core/Retrieval.java
@@ -74,7 +74,11 @@ public final class Retrieval {
     private final LinkedHashMap<String, Entry> entries =
         new LinkedHashMap<>(16, 0.75f, false) {
           @Override
-          protected boolean removeEldestEntry(Map.Entry<String, Entry> e) {
+          // Must be qualified: inside this anonymous LinkedHashMap subclass a bare
+          // `Entry` resolves to the inherited java.util.Map.Entry rather than the
+          // record above, and the resulting signature then clashes on erasure with
+          // the real one — a compile error, not a silent overload.
+          protected boolean removeEldestEntry(Map.Entry<String, InMemoryHotVectorIndex.Entry> e) {
             return size() > max;
           }
         };

--- a/ports/jagentic-core/src/test/java/org/jagentic/core/JAgenticCoreTest.java
+++ b/ports/jagentic-core/src/test/java/org/jagentic/core/JAgenticCoreTest.java
@@ -30,6 +30,22 @@ class JAgenticCoreTest {
   }
 
   @Test
+  void hotIndexEvictsBeyondItsCapacityBound() {
+    // Pins the "capacity-bounded" contract of InMemoryHotVectorIndex. javac already
+    // rejects a mistyped removeEldestEntry (erasure clash), so this covers the part
+    // the compiler cannot: that the eviction policy itself still bounds the window.
+    Retrieval.InMemoryHotVectorIndex hot = new Retrieval.InMemoryHotVectorIndex(3);
+    for (int i = 0; i < 10; i++) hot.upsert("k" + i, Retrieval.embed("doc " + i, 16), "doc " + i);
+    assertEquals(3, hot.size());
+
+    List<String> ids = hot.search(Retrieval.embed("doc 9", 16), 10).stream()
+        .map(Retrieval.Scored::id).toList();
+    assertEquals(3, ids.size());
+    assertTrue(ids.contains("k9"), "newest insert must survive eviction");
+    assertFalse(ids.contains("k0"), "eldest insert must have been evicted");
+  }
+
+  @Test
   void hotIndexKnnAndTwoTierDedup() {
     Retrieval.InMemoryHotVectorIndex hot = new Retrieval.InMemoryHotVectorIndex(100);
     hot.upsert("h1", Retrieval.embed("the cat sat on the mat", 64), "cat on mat");


### PR DESCRIPTION
Closes the first item from the audit: **the repo did not build from a clean checkout.**

`Retrieval.InMemoryHotVectorIndex` declared

```java
removeEldestEntry(Map.Entry<String, Entry> e)
```

inside an anonymous `LinkedHashMap` subclass. There a bare `Entry` resolves to the inherited `java.util.Map.Entry` rather than the enclosing record, and the resulting signature clashes on erasure with the real override — so javac rejects it outright:

```
name clash: removeEldestEntry(Map.Entry<String,Object>) ... and
removeEldestEntry(Map.Entry<String,...Entry>) in java.util.LinkedHashMap
have the same erasure, yet neither overrides the other
```

Qualifying it as `InMemoryHotVectorIndex.Entry` restores the override.

## Why it mattered

`jagentic-core` is a **hard compile-scope dependency** of the main module (`pom.xml:90-94`), so nothing in the JVM tree built — including the `mvn clean test` documented in CLAUDE.md. Introduced in 0424ea3 and never caught because **no CI workflow compiles Java** (tracked as AGS-22; `.github/workflows/` contains only the two PyPI publish jobs).

## Test

Adds `hotIndexEvictsBeyondItsCapacityBound`. javac already catches a mistyped signature, so the test deliberately covers what the compiler cannot: that the eviction policy still bounds the window. Verified it fails (`expected: <3> but was: <10>`) when the bound is disabled by an edit that *does* compile.

## Verification

Run with `~/.m2/repository/org/jagentic` purged, so no stale artifact could mask the result — JDK 21:

| Step | Result |
|---|---|
| `mvn -f ports/jagentic-core/pom.xml install` | **95 tests, 0 failures** (5 skipped: external-infra) |
| `mvn clean test` | **770 tests, 0 failures, 0 skipped** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)