### PR TITLE
AGS-22: add CI that builds and tests every language surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,155 @@
+name: CI
+
+# Builds and tests every language surface in the repo. Until this existed, the
+# only automation was the two PyPI publish jobs — nothing compiled Java, and a
+# compile error in ports/jagentic-core (AGS-9) left the whole JVM tree
+# unbuildable from a clean checkout without anyone noticing.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  jvm:
+    name: JVM (Java 21)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # The build order below is manual because there is no Maven reactor: the
+      # root pom has no <modules> and every module is built by an explicit -f.
+      # ports/jagentic-core is a hard compile-scope dependency of the main
+      # module and is not published anywhere, so it has to be installed first.
+      # AGS-10 tracks replacing this with a real parent pom.
+      - name: jagentic-core (shared JVM core)
+        run: mvn -B -ntp -f ports/jagentic-core/pom.xml install
+
+      # `install` rather than `test`: runs the main suite AND publishes the
+      # artifact that a2a-gateway and banking-job depend on.
+      - name: agentic-flink (main module)
+        run: mvn -B -ntp install
+
+      - name: ports/kafka-streams
+        run: mvn -B -ntp -f ports/kafka-streams/pom.xml test
+      - name: ports/spring
+        run: mvn -B -ntp -f ports/spring/pom.xml test
+      - name: ports/quarkus
+        run: mvn -B -ntp -f ports/quarkus/pom.xml test
+      - name: ports/temporal
+        run: mvn -B -ntp -f ports/temporal/pom.xml test
+      - name: ports/pekko
+        run: mvn -B -ntp -f ports/pekko/pom.xml test
+      - name: ports/pulsar
+        run: mvn -B -ntp -f ports/pulsar/pom.xml test
+
+      - name: agentic-pekko (actor runtime)
+        run: mvn -B -ntp -f agentic-pekko/pom.xml test
+
+      - name: tool-services (packs, then app)
+        run: |
+          mvn -B -ntp -f tool-services/tool-services-packs/pom.xml install
+          mvn -B -ntp -f tool-services/tool-services-app/pom.xml test
+
+      - name: a2a-gateway
+        run: mvn -B -ntp -f a2a-gateway/pom.xml test
+
+      - name: banking-job (uber-jar assembly)
+        run: mvn -B -ntp -f banking-job/pom.xml test
+
+      - name: Collect surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/*.txt"
+          if-no-files-found: warn
+          retention-days: 7
+
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ports/go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ports/go/go.mod
+          cache-dependency-path: ports/go/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...
+
+  clojure:
+    name: Clojure (Datomic runtime)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          cli: latest
+
+      - name: Cache clojure deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: clj-${{ runner.os }}-${{ hashFiles('agentic-clj/deps.edn') }}
+          restore-keys: clj-${{ runner.os }}-
+
+      - name: clojure -X:test
+        working-directory: agentic-clj
+        run: clojure -X:test
+
+  python:
+    name: Python (pyagentic + adapters)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # `celery` is needed because ports/tests exercises the Celery adapter
+      # against the real engine in eager mode (no broker required); without it
+      # two tests hard-fail rather than skipping.
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "ports/pyagentic[test]" celery
+
+      - name: pyagentic
+        run: python -m pytest ports/pyagentic/tests -q
+
+      - name: port adapters
+        run: python -m pytest ports/tests -q

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,8 +3,12 @@ name: Publish Python package to PyPI
 # Fires on every published GitHub Release.
 # Uses PyPI Trusted Publishing (OIDC) — no API tokens stored in this repo.
 # Configure the trusted publisher once on https://pypi.org/manage/account/publishing/
-# (project: agentic-flink, owner: Ugbot, repo: Agentic-Flink, workflow: publish-pypi.yml,
+# (project: agentic-flink, owner: Ugbot, repo: Agentic-Streaming, workflow: publish-pypi.yml,
 #  environment: pypi).
+#
+# NOTE: the repo was renamed Agentic-Flink -> Agentic-Streaming. PyPI matches the
+# OIDC token's `repository` claim exactly, so the trusted publisher must be
+# re-registered against Agentic-Streaming on pypi.org or this upload is rejected.
 
 on:
   release:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -2,8 +2,11 @@ name: Publish Python package to TestPyPI
 
 # Manual dispatch only — use this to rehearse a release on TestPyPI before the
 # real one. Trusted Publishing must be configured separately on test.pypi.org.
-# (project: agentic-flink, owner: Ugbot, repo: Agentic-Flink, workflow:
+# (project: agentic-flink, owner: Ugbot, repo: Agentic-Streaming, workflow:
 #  publish-testpypi.yml, environment: testpypi).
+#
+# NOTE: the repo was renamed Agentic-Flink -> Agentic-Streaming; re-register the
+# trusted publisher against the new name or the upload is rejected.
 
 on:
   workflow_dispatch:

--- a/ports/pyagentic/pyproject.toml
+++ b/ports/pyagentic/pyproject.toml
@@ -10,7 +10,9 @@ requires-python = ">=3.9"
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest>=7"]
+# PyYAML is needed by tests/test_cep_weave.py, which drives the sibling
+# agentic-pipeline YAML loader. The library itself still has no runtime deps.
+test = ["pytest>=7", "PyYAML>=6"]
 
 [tool.setuptools.packages.find]
 include = ["pyagentic*"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,10 +33,10 @@ test = ["pytest>=7"]
 all = ["agentic-flink[pyflink,test]"]
 
 [project.urls]
-Homepage = "https://github.com/Ugbot/Agentic-Flink"
-Repository = "https://github.com/Ugbot/Agentic-Flink"
-Issues = "https://github.com/Ugbot/Agentic-Flink/issues"
-Documentation = "https://github.com/Ugbot/Agentic-Flink/blob/main/docs/python.md"
+Homepage = "https://github.com/Ugbot/Agentic-Streaming"
+Repository = "https://github.com/Ugbot/Agentic-Streaming"
+Issues = "https://github.com/Ugbot/Agentic-Streaming/issues"
+Documentation = "https://github.com/Ugbot/Agentic-Streaming/blob/main/docs/python.md"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
Before this, the only automation in the repo was the two PyPI publish jobs. **Nothing compiled Java**, ran `pytest`, `go test`, or `clojure -X:test` — which is exactly why AGS-9 (a compile error that left the whole JVM tree unbuildable from a clean checkout) sat unnoticed. This PR is its own proof: the checks below are the first ones this repo has ever run.

## Jobs

| Job | Covers |
|---|---|
| **jvm** (Java 21) | `jagentic-core` → `agentic-flink` → 6 `ports/*` → `agentic-pekko` → `tool-services` → `a2a-gateway` → `banking-job` |
| **go** | `go vet ./...` + `go test ./...` over `ports/go` |
| **clojure** | `clojure -X:test` over `agentic-clj` |
| **python** | `pyagentic` + the port adapter suite |

The JVM ordering is manual because there is no Maven reactor (**AGS-10**) — `jagentic-core` is an unpublished hard compile-scope dependency, so it must be installed before anything else resolves. Surefire reports upload on failure.

## Two bugs CI immediately surfaced, fixed here

- **`ports/pyagentic` never declared PyYAML**, so `test_cep_weave` failed on any clean machine (1 failed / 87 passed). Added to the `test` extra → 88 pass.
- **`ports/tests` hard-failed without Celery** instead of skipping, so the job installs it. The adapter tests then run for real in eager mode, no broker needed.

## Also fixed

The publish workflows and `python/pyproject.toml` still pointed at the pre-rename `Agentic-Flink` repo — 4 dead URLs. Corrected, with a note that the **PyPI trusted publisher must be re-registered** against `Agentic-Streaming`, since PyPI matches the OIDC `repository` claim exactly (AGS-30). That part cannot be fixed from the repo side.

## Verified locally before pushing

Ran the exact step sequence on JDK 21 with `~/.m2/repository/org/{jagentic,agentic}` **purged**, so nothing stale could mask a break:

- **922 tests green across 13 JVM modules** (jagentic-core 95, main 770, ports 6, agentic-pekko 14, tool-services 26, a2a-gateway 9)
- `go vet` clean, 6/6 Go packages
- 64 Clojure tests / 249 assertions
- 88 pyagentic + 7 adapter tests

## Deliberately not included

**Spotless is not a gate.** `spotless:check` fails on code already in `main`, and `apply` is bound to the default lifecycle so every build rewrites sources. Flipping it to `check` needs a repo-wide format commit first — shipping it now would mean a permanently red job.

Container-backed integration tests are also out of scope for v1: `*IT.java` files are currently unrunnable in every profile (no failsafe plugin), tracked as **AGS-23**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)